### PR TITLE
Added functionalities

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,3 +18,5 @@ Implementation of StereoLab's ZED camera for openFrameworks
 
 #Credits
 Put together for openFrameworks by <a href="http://designandsystems.de">Design & Systems</a> / <a href="http://www.stefanwagner.io">Stefan Wagner (andsynchrony)</a> 
+
+Some functionalities extended by <a href="http://mithru.com/"> Mithru Vigneshwara</a>.

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Implementation of StereoLab's ZED camera for openFrameworks
 - <a href="http://openframeworks.cc/download/">openFrameworks 0.9 for x64 builds</a>
 - <a href="https://www.visualstudio.com/">Visual Studio 2015</a>
 - <a href="https://www.stereolabs.com/developers/#start_anchor">ZED driver's and SDK</a>
-- <a href="https://developer.nvidia.com/cuda-toolkit-70">NVIDIA Cuda</a> (tested with 7.0)
+- <a href="https://developer.nvidia.com/cuda-toolkit-70">NVIDIA Cuda</a> (tested with 7.0 and 7.5)
 
 
 #Installation:

--- a/src/example/ofApp.cpp
+++ b/src/example/ofApp.cpp
@@ -3,7 +3,7 @@
 //--------------------------------------------------------------
 void ofApp::setup()
 {
-	zed.init(true, true, 0, sl::zed::PERFORMANCE, sl::zed::VGA);
+	zed.init(true, true, 0, sl::zed::PERFORMANCE, sl::zed::VGA, 60);
 	//zed.init();
 }
 
@@ -11,14 +11,14 @@ void ofApp::setup()
 void ofApp::update()
 {
 	zed.update();
-	ofLog() << "FPS: " << zed.getCurrentFPS() << endl;
+	//ofLog() << "FPS: " << zed.getCurrentFPS() << endl;
 }
 
 //--------------------------------------------------------------
 void ofApp::draw()
 {
 	zed.getColorTexture()->draw(0, 0);
-	//zed.getDepthTexture()->draw(0, 0);
+	zed.getDepthTexture()->draw(zed.zedWidth, 0);
 }
 
 //--------------------------------------------------------------
@@ -38,7 +38,7 @@ void ofApp::mouseMoved(int x, int y ){
 
 //--------------------------------------------------------------
 void ofApp::mouseDragged(int x, int y, int button){
-
+	ofLog() << "Depth at (" << x << ", " << y << ") is " << zed.getDepthAtPoint(x, y) << " mm" << endl;
 }
 
 //--------------------------------------------------------------

--- a/src/example/ofApp.cpp
+++ b/src/example/ofApp.cpp
@@ -3,13 +3,15 @@
 //--------------------------------------------------------------
 void ofApp::setup()
 {
-	zed.init(true, true);
+	zed.init(true, true, 0, sl::zed::PERFORMANCE, sl::zed::VGA);
+	//zed.init();
 }
 
 //--------------------------------------------------------------
 void ofApp::update()
 {
 	zed.update();
+	ofLog() << "FPS: " << zed.getCurrentFPS() << endl;
 }
 
 //--------------------------------------------------------------

--- a/src/ofxZED.cpp
+++ b/src/ofxZED.cpp
@@ -1,25 +1,24 @@
 #include "ofxZED.h"
 
-
-
 ofxZED::ofxZED()
 {
 }
-
 
 ofxZED::~ofxZED()
 {
 }
 
-
-void ofxZED::init(bool useColorImage, bool useDepthImage)
+void ofxZED::init(bool useColorImage, bool useDepthImage, int cameraID, sl::zed::MODE mode, sl::zed::ZEDResolution_mode resolution, float fps)
 {
 	bUseColorImage = useColorImage;
 	bUseDepthImage = useDepthImage;
+
 	ofLog() << "Initializing ZED camera." << std::endl;
 
-	zed = new sl::zed::Camera(sl::zed::HD720);
-	sl::zed::ERRCODE zederr = zed->init(sl::zed::MODE::PERFORMANCE, 0, false, false, false);
+	zed = new sl::zed::Camera(resolution, fps);
+	ofLog() << "Resolution Mode:" << resolution << std::endl;
+
+	sl::zed::ERRCODE zederr = zed->init(mode, cameraID, true, false, false);
 
 	if (zederr != sl::zed::SUCCESS)
 	{
@@ -29,10 +28,14 @@ void ofxZED::init(bool useColorImage, bool useDepthImage)
 	else
 	{
 		ofLog() << "ZED initialized." << endl;
+
 	}
 
 	zedWidth = zed->getImageSize().width;
 	zedHeight = zed->getImageSize().height;
+
+	ofLog() << "Resolution: " << zedWidth << ", " << zedHeight << endl;
+	ofLog() << "FPS: " << getCurrentFPS() << endl;
 
 	colorBuffer = new uchar[zedWidth * zedHeight * 3];
 	depthBuffer = new uchar[zedWidth * zedHeight];
@@ -44,6 +47,11 @@ void ofxZED::init(bool useColorImage, bool useDepthImage)
 ofVec2f ofxZED::getImageDimensions()
 {
 	return ofVec2f(zedWidth, zedHeight);
+}
+
+float ofxZED::getCurrentFPS() 
+{
+	return zed->getCurrentFPS();
 }
 
 
@@ -92,7 +100,6 @@ void ofxZED::fillColorBuffer()
 void ofxZED::fillDepthBuffer()
 {
 	sl::zed::Mat zedView = zed->normalizeMeasure(sl::zed::MEASURE::DEPTH);
-	ofLog() << zedView.width << " // " << zedView.height << endl;
 	for (int y = 0; y < zedHeight; y++)
 	{
 		for (int x = 0; x < zedWidth; x++)

--- a/src/ofxZED.cpp
+++ b/src/ofxZED.cpp
@@ -59,11 +59,11 @@ void ofxZED::update()
 {
 	if (bUseDepthImage)
 	{
-		zed->grab(sl::zed::SENSING_MODE::FULL, true, true);
+		zed->grab(sl::zed::SENSING_MODE::RAW, true, true);
 	}
 	else if(bUseColorImage)
 	{
-		zed->grab(sl::zed::SENSING_MODE::RAW, false, false);
+		zed->grab(sl::zed::SENSING_MODE::FULL, false, false);
 	}
 
 	if(bUseColorImage)
@@ -95,6 +95,29 @@ void ofxZED::fillColorBuffer()
 		}
 	}
 	
+}
+
+
+int ofxZED::getDepthAtPoint(int x, int y) {
+	try {
+
+		cv::Mat depthMap(zedHeight, zedWidth, CV_32F);
+
+		slMat2cvMat(zed->retrieveMeasure(sl::zed::MEASURE::DEPTH)).copyTo(depthMap);
+
+		if (x >= 0 && y >= 0 && x < zedWidth && y < zedHeight) 
+		{
+			return depthMap.at<float>(y, x);
+		}
+		else
+		{
+			ofLog(OF_LOG_ERROR) << "ERROR: Out of Bounds. Image resolution is " << zedWidth << ", " << zedHeight << ". Pick a point within the frame." << std::endl;
+			return -1;
+		}
+	}
+	catch (int e) {
+		ofLog(OF_LOG_ERROR) << "Could not get depth at point. Error: " << e << std::endl;
+	}
 }
 
 void ofxZED::fillDepthBuffer()

--- a/src/ofxZED.h
+++ b/src/ofxZED.h
@@ -8,7 +8,7 @@ class ofxZED
 public:
 	ofxZED();
 	~ofxZED();
-	void init(bool useColorImage = true, bool useDepthImage = true);
+	void init(bool useColorImage = true, bool useDepthImage = true, int cameraID = 0, sl::zed::MODE mode = sl::zed::PERFORMANCE, sl::zed::ZEDResolution_mode resolution = sl::zed::HD720, float fps = 0.0);
 	void update();
 	uchar * getColorBuffer();
 	uchar * getDepthBuffer();
@@ -16,6 +16,11 @@ public:
 
 	ofTexture * getColorTexture();
 	ofTexture * getDepthTexture();
+
+	int zedWidth;
+	int zedHeight;
+
+	float getCurrentFPS();
 
 private:
 	void fillColorBuffer();
@@ -25,8 +30,6 @@ private:
 	bool bUseDepthImage;
 
 	sl::zed::Camera* zed = 0;
-	int zedWidth;
-	int zedHeight;
 	uchar * colorBuffer;
 	uchar * depthBuffer;
 	ofTexture colorTexture;

--- a/src/ofxZED.h
+++ b/src/ofxZED.h
@@ -22,6 +22,8 @@ public:
 
 	float getCurrentFPS();
 
+	int getDepthAtPoint(int x, int y);
+
 private:
 	void fillColorBuffer();
 	void fillDepthBuffer();


### PR DESCRIPTION
Hi,

Before I describe the changes I made, there's one issue that I could not fix:

When I build the app the first time it's fine, but when I stop/close the app and build it the second time, it stalls at `zed->init().` To be precise, it stalls after setting the disparity mode (enable verbose in `zed->init()` to check). And when this happens, I have to kill the app, unplug and re-plug the zed camera. 

This happens even when I use your current repository (i.e. before any of my changes). Any ideas on why this happens? I couldn't figure it out so far. If you're not able to reproduce this, I suggest not merging yet. It could be my GPU - let me check if I can reproduce on another machine. 

That aside, I've added some features:

**Set your own camera settings** 
Don't have to go inside ofxZED.cpp for any changes in resolution or fps:

```
zed.init(true, true, 0, sl::zed::PERFORMANCE, sl::zed::VGA, 60); // params are (useColorImage, useDepthImage, Camera ID, Camera Setting, Resolution, FPS)
```

You can also not have any parameters and use default values:

```
zed.update(); // uses (true, true, 0, PERFORMANCE, HD720, 0.0);
```

**Get the actual depth in mm**

```
int depth = getDepthAtPoint(x,y); // returns int (depth in mm)
```

**Get current FPS**

```
 float FPS = zed.getCurrentFPS();
```

**One more change that needs to be noted:**

I swapped the SENSING_MODE for the depth image and color image. I'm not sure if I understand correctly, but when I read the [docs](https://www.stereolabs.com/developers/documentation/API/group__Enumerations.html#gga546997a3c773f580b5a2e612bc910f4fa1c9b6343049186009fb9d0d43284e18a) I get the feeling that for depth calculation, it makes more sense to get the RAW values, as opposed to corrected ones. 

```
zed->grab(sl::zed::SENSING_MODE::RAW, true, true); // used to be FULL
```

Also, made a few changes to the README to update that I tested on CUDA version 7.5 and added credits.
